### PR TITLE
Remove version from show-plugin btest in prep for Bro 2.7

### DIFF
--- a/tests/Baseline/community-id.show-plugin/output
+++ b/tests/Baseline/community-id.show-plugin/output
@@ -1,3 +1,3 @@
-Corelight::CommunityID - "Community ID" flow hash support in the connection log (dynamic, version 1.0)
+Corelight::CommunityID - "Community ID" flow hash support in the connection log (dynamic, version)
     [Function] CommunityID::hash_conn
 

--- a/tests/community-id/show-plugin.bro
+++ b/tests/community-id/show-plugin.bro
@@ -1,2 +1,2 @@
-# @TEST-EXEC: bro -NN Corelight::CommunityID >output
+# @TEST-EXEC: bro -NN Corelight::CommunityID |sed -e 's/version.*)/version)/g' >output
 # @TEST-EXEC: btest-diff output


### PR DESCRIPTION
Update show-plugin.bro test to remove the version number from the baseline output.
With Bro 2.7, the version will be built from major.minor.patch, which conflicts with
the current major.minor in the baseline.
