### PR TITLE
Look for OpenSSL

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,20 +5,33 @@ project(ZeekPluginCommunityID)
 
 include(ZeekPlugin)
 
-zeek_plugin_begin(Corelight CommunityID)
-zeek_plugin_cc(src/Plugin.cc)
-zeek_plugin_bif(src/communityid.bif)
-zeek_plugin_dist_files(README COPYING VERSION)
-zeek_plugin_end()
+include(FindOpenSSL)
 
-file(STRINGS "${CMAKE_CURRENT_SOURCE_DIR}/VERSION" VERSION LIMIT_COUNT 1)
+message("OPENSSL_INCLUDE_DIR: ${OPENSSL_INCLUDE_DIR}")
+message("OPENSSL_LIBRARIES: ${OPENSSL_LIBRARIES}")
+message("OPENSSL_VERSION: ${OPENSSL_VERSION}")
 
-if ("${BRO_HAS_OLD_DIGEST_CODE}")
-   add_definitions(-DBRO_HAS_OLD_DIGEST_CODE)
-endif ()
+if (OPENSSL_FOUND)
 
-if ("${PROJECT_SOURCE_DIR}" STREQUAL "${CMAKE_SOURCE_DIR}")
-    # Allows building rpm/deb packages via "make package" in build dir.
-    include(ConfigurePackaging)
-    ConfigurePackaging(${VERSION})
+    zeek_plugin_begin(Corelight CommunityID)
+    zeek_plugin_cc(src/Plugin.cc)
+    zeek_plugin_bif(src/communityid.bif)
+    zeek_plugin_dist_files(README COPYING VERSION)
+    include_directories(BEFORE ${OPENSSL_INCLUDE_DIR})
+
+    zeek_plugin_end()
+
+    file(STRINGS "${CMAKE_CURRENT_SOURCE_DIR}/VERSION" VERSION LIMIT_COUNT 1)
+
+    if ("${BRO_HAS_OLD_DIGEST_CODE}")
+       add_definitions(-DBRO_HAS_OLD_DIGEST_CODE)
+    endif ()
+
+    if ("${PROJECT_SOURCE_DIR}" STREQUAL "${CMAKE_SOURCE_DIR}")
+        # Allows building rpm/deb packages via "make package" in build dir.
+        include(ConfigurePackaging)
+        ConfigurePackaging(${VERSION})
+    endif ()
+else ()
+    message(FATAL_ERROR "OpenSSL not found.")
 endif ()


### PR DESCRIPTION
When I tried to install this package on macOS, it fails with:

```
In file included from communityid.bif:6:
/usr/local/zeek-3.1.4/include/zeek/digest.h:9:10: fatal error: 'openssl/md5.h' file not found
#include <openssl/md5.h>
         ^~~~~~~~~~~~~~~
1 error generated.
make[2]: *** [CMakeFiles/Corelight-CommunityID.darwin-x86_64.dir/communityid.bif.cc.o] Error 1
make[1]: *** [CMakeFiles/Corelight-CommunityID.darwin-x86_64.dir/all] Error 2
make: *** [all] Error 2
```

Articles like [this](https://github.com/coturn/coturn/issues/242) point out that a `brew`-installed OpenSSL (as may be typical on macOS) will not have headers/libs in standard locations. The changes in this PR allow them to be found & used even in their non-standard locations.

In addition to testing this on macOS, I also tested it successfully on Linux.