### PR TITLE
Require OpenSSL in CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,10 @@ cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
 
 project(ZeekPluginCommunityID)
 
+include(MacDependencyPaths)
+find_package(OpenSSL REQUIRED)
+include_directories(BEFORE ${OPENSSL_INCLUDE_DIR})
+
 include(ZeekPlugin)
 
 zeek_plugin_begin(Corelight CommunityID)


### PR DESCRIPTION
When I tried to install this package on macOS, it fails with:

```
In file included from communityid.bif:6:
/usr/local/zeek-3.1.4/include/zeek/digest.h:9:10: fatal error: 'openssl/md5.h' file not found
#include <openssl/md5.h>
         ^~~~~~~~~~~~~~~
1 error generated.
make[2]: *** [CMakeFiles/Corelight-CommunityID.darwin-x86_64.dir/communityid.bif.cc.o] Error 1
make[1]: *** [CMakeFiles/Corelight-CommunityID.darwin-x86_64.dir/all] Error 2
make: *** [all] Error 2
```

Articles like [this](https://github.com/coturn/coturn/issues/242) point out that a `brew`-installed OpenSSL (as may be typical on macOS) will not have headers/libs in standard locations. The changes in this PR allow them to be found & used even in their non-standard locations.

In addition to testing this on macOS, I also tested it successfully on Linux.