### PR TITLE
Add Github workflows using Zeek's action-zkg-install

### DIFF
--- a/.github/workflows/zeek-matrix.yml
+++ b/.github/workflows/zeek-matrix.yml
@@ -1,0 +1,24 @@
+name: Zeek matrix tests
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    name: test-${{ matrix.zeekver }}
+    runs-on: ubuntu-20.04
+    strategy:
+      fail-fast: false
+      matrix:
+        zeekver: [zeek, zeek-lts, zeek-nightly]
+    steps:
+      - uses: actions/checkout@v2
+      - uses: zeek/action-zkg-install@v1
+        with:
+          zeek_version: ${{ matrix.zeekver }}
+      - uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          name: zkg-logs-${{ matrix.zeekver }}
+          path: ${{ github.workspace }}/.action-zkg-install/artifacts

--- a/.github/workflows/zeek-nightly.yml
+++ b/.github/workflows/zeek-nightly.yml
@@ -1,0 +1,19 @@
+name: Zeek nightly build
+
+on:
+  schedule:
+    - cron: '30 0 * * *'
+
+jobs:
+  test-nightly:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: zeek/action-zkg-install@v1
+        with:
+          pkg: ${{ github.server_url }}/${{ github.repository }}
+          zeek_version: 'zeek-nightly'
+      - uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          name: zkg-logs
+          path: ${{ github.workspace }}/.action-zkg-install/artifacts

--- a/README
+++ b/README
@@ -1,5 +1,8 @@
 # "Community ID" flow hashing for Zeek
 
+[![Zeek matrix tests](https://github.com/ckreibich/zeek-community-id/actions/workflows/zeek-matrix.yml/badge.svg)](https://github.com/ckreibich/zeek-community-id/actions/workflows/zeek-matrix.yml)
+[![Zeek nightly build](https://github.com/ckreibich/zeek-community-id/actions/workflows/zeek-nightly.yml/badge.svg)](https://github.com/ckreibich/zeek-community-id/actions/workflows/zeek-nightly.yml)
+
 This Zeek package provides support for "community ID" flow hashing, a
 standardized way of labeling traffic flows in network monitors. When
 loaded, the package adds a `community_id` string field to


### PR DESCRIPTION
This includes matrix testing upon any change for the three versions
supported by binary packages, and nightly-build testing for the latest
tagged version.