### PR TITLE
Automate version number management, plus minor modernizations

### DIFF
--- a/.github/workflows/zeek-matrix.yml
+++ b/.github/workflows/zeek-matrix.yml
@@ -2,22 +2,23 @@ name: Zeek matrix tests
 
 on:
   push:
+    branches: [master]
   pull_request:
 
 jobs:
   test:
     name: test-${{ matrix.zeekver }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         zeekver: [zeek, zeek-lts, zeek-nightly]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: zeek/action-zkg-install@v1.2
         with:
           zeek_version: ${{ matrix.zeekver }}
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         if: failure()
         with:
           name: zkg-logs-${{ matrix.zeekver }}

--- a/.github/workflows/zeek-nightly.yml
+++ b/.github/workflows/zeek-nightly.yml
@@ -6,13 +6,13 @@ on:
 
 jobs:
   test-nightly:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: zeek/action-zkg-install@v1.2
         with:
           pkg: ${{ github.server_url }}/${{ github.repository }}
           zeek_version: 'zeek-nightly'
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         if: failure()
         with:
           name: zkg-logs

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,19 @@ cmake_minimum_required(VERSION 3.12 FATAL_ERROR)
 
 project(ZeekPluginCommunityID)
 
+# Establish version numbers in config.h
+file(STRINGS "${CMAKE_CURRENT_SOURCE_DIR}/VERSION" VERSION LIMIT_COUNT 1)
+
+string(REGEX REPLACE "[.-]" " " version_numbers ${VERSION})
+separate_arguments(version_numbers)
+list(GET version_numbers 0 VERSION_MAJOR)
+list(GET version_numbers 1 VERSION_MINOR)
+list(GET version_numbers 2 VERSION_PATCH)
+add_compile_definitions(
+    VERSION_MAJOR=${VERSION_MAJOR}
+    VERSION_MINOR=${VERSION_MINOR}
+    VERSION_PATCH=${VERSION_PATCH})
+
 include(MacDependencyPaths)
 find_package(OpenSSL REQUIRED)
 include_directories(BEFORE ${OPENSSL_INCLUDE_DIR})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,4 @@
-
-cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.12 FATAL_ERROR)
 
 project(ZeekPluginCommunityID)
 

--- a/src/Plugin.cc
+++ b/src/Plugin.cc
@@ -1,4 +1,3 @@
-
 #include "Plugin.h"
 
 namespace plugin { namespace Corelight_CommunityID { Plugin plugin; } }
@@ -10,8 +9,8 @@ zeek::plugin::Configuration Plugin::Configure()
 	zeek::plugin::Configuration config;
 	config.name = "Corelight::CommunityID";
 	config.description = "\"Community ID\" flow hash support in the connection log";
-	config.version.major = 3;
-	config.version.minor = 2;
-	config.version.patch = 0;
+	config.version.major = VERSION_MAJOR;
+	config.version.minor = VERSION_MINOR;
+	config.version.patch = VERSION_PATCH;
 	return config;
 	}

--- a/src/communityid.bif
+++ b/src/communityid.bif
@@ -49,7 +49,7 @@ static int digest_update_logger(Ctx* ctx, const void* data,
 
 function hash_conn%(conn: connection%): string
 %{
-    bro_uint_t comm_id_seed = 0;
+    zeek_uint_t comm_id_seed = 0;
     bool do_base64 = true;
     bool verbose = false;
     zeek::detail::IDPtr id;

--- a/src/zeek-compat.h
+++ b/src/zeek-compat.h
@@ -1,15 +1,22 @@
 #pragma once
 
-// Modest compatibility wrappers for differences between the Zeek 3.2
-// series and 4.0+. If things become too cumbersome to handle via this
-// header, we fork a dedicated zeek/x.y branch.
+// Modest compatibility wrappers for differences between Zeek versions.
+// If things become too cumbersome to handle via this header, we will
+// fork a dedicated zeek/x.y branch.
 
 // We drive the compatibilities purely from Zeek version numbers
 // (available since Zeek 3.1) since it saves us from implementing
 // feature checks.
 
-// Namespacing tweaks
 #include <zeek/zeek-config.h>
+
+// bro_uint_t vs zeek_uint_t: we have the latter as of 5.1, and lose the former
+// in 6.1.
+#if ZEEK_VERSION_NUMBER < 50100
+#define zeek_uint_t bro_uint_t
+#endif
+
+// Namespacing tweaks
 #if ZEEK_VERSION_NUMBER >= 30200 && ZEEK_VERSION_NUMBER < 40000
 #define ZEEK_DETAIL_NS
 #elif ZEEK_VERSION_NUMBER >= 40000


### PR DESCRIPTION
The version number reported by the plugin in Zeek was still hardwired, and had become inconsistent with the one spelled out in the `VERSION` file. The package now produces the plugin-level version number automatically.