### PR TITLE
zeek-compat: Use zeek-version.h when available

### DIFF
--- a/src/zeek-compat.h
+++ b/src/zeek-compat.h
@@ -8,7 +8,11 @@
 // (available since Zeek 3.1) since it saves us from implementing
 // feature checks.
 
+#if __has_include(<zeek/zeek-version.h>)
+#include <zeek/zeek-version.h>
+#else
 #include <zeek/zeek-config.h>
+#endif
 
 // bro_uint_t vs zeek_uint_t: we have the latter as of 5.1, and lose the former
 // in 6.1.


### PR DESCRIPTION
Currently, due to zeek/zeek#2806, zeek-config.h is not providing ZEEK_VERSION_NUMBER to plugins that are builtin.

I'd like to include community-id into a builtin-plugin CI test and for the time being it would be "nice" to have the fallback to zeek/zeek-version.h.