### PR TITLE
Bump cmake requirement to that of current Zeek master (3.15)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.12 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.15 FATAL_ERROR)
 
 project(ZeekPluginCommunityID)
 


### PR DESCRIPTION
This avoids a warning (or worse) with our upcoming, revamped cmake infrastructure for Zeek plugins.